### PR TITLE
Fix CORS handling and update transcript processing logic

### DIFF
--- a/supabase/functions/transcribe-audio/index.ts
+++ b/supabase/functions/transcribe-audio/index.ts
@@ -121,6 +121,7 @@ Deno.serve(async (req) => {
     audioUrl: audioMp3SignedUrl,
     textUrl: audioTextSignedUrl,
     jsonUrl: audioJsonSignedUrl,
+    transcriptTextPath: audioTextFilePath,
   }
 
 

--- a/supabase/functions/transcribe-audio/index.ts
+++ b/supabase/functions/transcribe-audio/index.ts
@@ -13,7 +13,16 @@ const addFileNameSafety = (fileName: string): string => {
   return `${prefix}${name}`;
 }
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
 Deno.serve(async (req) => {
+  // Handle CORS preflight request
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
   if (req.method !== "POST") {
     return new Response(
       JSON.stringify({ error: "Method not allowed. Use POST." }),

--- a/supabase/functions/validate-lead/configs.ts
+++ b/supabase/functions/validate-lead/configs.ts
@@ -3,8 +3,9 @@ import { createClient } from 'npm:@supabase/supabase-js@2';
 const _env = z.object({
   SUPABASE_URL: z.string().url(),
   SUPABASE_ANON_KEY: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string(),
   G_OPENAI_API_KEY: z.string()
 });
 export const env = _env.parse(Deno.env.toObject());
-export const supabaseClient = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY);
+export const supabaseClient = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 export const OPENAI_KEY = env.G_OPENAI_API_KEY;

--- a/supabase/functions/validate-lead/interfaces.ts
+++ b/supabase/functions/validate-lead/interfaces.ts
@@ -170,7 +170,7 @@ export interface MelissaContext {
 
 
 export interface RequestPayload {
-    transcript: string;
+    transcriptTextPath: string;
     phoneNumber: string;
     melissaData?: MelissaContext;
 }


### PR DESCRIPTION
Enhance the transcribe-audio function to handle CORS preflight requests and return the transcript text path. Update the validate-lead function to accept the transcript text path instead of raw text, ensuring proper validation with the Supabase service role key.

Signed-off-by: Gilang R Ilhami <gilangrilhami@hotmail.co.uk>